### PR TITLE
feat!: allow to skip solidity version detection (#67)

### DIFF
--- a/.lintspec.toml
+++ b/.lintspec.toml
@@ -1,8 +1,9 @@
 [lintspec]
-paths = []            # paths to files and folders to analyze
-exclude = []          # paths to files or folders to exclude, see also `.nsignore`
-inheritdoc = true     # enforce that all overridden, public and external items have `@inheritdoc`
-notice_or_dev = false # do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+paths = []                     # paths to files and folders to analyze
+exclude = []                   # paths to files or folders to exclude, see also `.nsignore`
+inheritdoc = true              # enforce that all overridden, public and external items have `@inheritdoc`
+notice_or_dev = false          # do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+skip_version_detection = false # skip detection of the Solidity version from pragma statements and use the latest
 
 [output]
 # out = ""        # if provided, redirects output to this file

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
   -o, --out <OUT>                Write output to a file instead of stderr
       --inheritdoc               Enforce that all public and external items have `@inheritdoc`
       --notice-or-dev            Do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+      --skip-version-detection   Skip the detection of the Solidity version from pragma statements
       --notice-ignored <TYPE>    Ignore `@notice` for these items (can be used more than once)
       --notice-required <TYPE>   Enforce `@notice` for these items (can be used more than once)
       --notice-forbidden <TYPE>  Forbid `@notice` for these items (can be used more than once)

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,10 @@ pub struct BaseConfig {
     /// Do not distinguish between `@notice` and `@dev` when considering "required" validation rules
     #[builder(default)]
     pub notice_or_dev: bool,
+
+    /// Skip the detection of the Solidity version and use the latest version supported by [`slang_solidity`]
+    #[builder(default)]
+    pub skip_version_detection: bool,
 }
 
 impl Default for BaseConfig {
@@ -290,6 +294,7 @@ impl Default for BaseConfig {
             exclude: Vec::default(),
             inheritdoc: true,
             notice_or_dev: false,
+            skip_version_detection: false,
         }
     }
 }
@@ -398,10 +403,10 @@ impl Config {
             .admerge(Toml::file(".lintspec.toml"))
             .admerge(Env::prefixed("LS_").split("_").map(|k| {
                 // special case for parameters with an underscore in the name
-                if k == "LINTSPEC.NOTICE.OR.DEV" {
-                    "LINTSPEC.NOTICE_OR_DEV".into()
-                } else {
-                    k.into()
+                match k.as_str() {
+                    "LINTSPEC.NOTICE.OR.DEV" => "LINTSPEC.NOTICE_OR_DEV".into(),
+                    "LINTSPEC.SKIP.VERSION.DETECTION" => "LINTSPEC.SKIP_VERSION_DETECTION".into(),
+                    _ => k.into(),
                 }
             }))
     }
@@ -461,6 +466,15 @@ pub struct Args {
     /// Can be set with `--notice-or-dev` (means true), `--notice-or-dev=true` or `--notice-or-dev=false`.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub notice_or_dev: Option<bool>,
+
+    /// Skip the detection of the Solidity version from pragma statements and use the latest supported version.
+    ///
+    /// This is useful to speed up parsing slightly, or if the Solidity version is newer than the latest version
+    /// supported by the parser.
+    ///
+    /// Can be set with `--skip-version-detection` (means true), `--skip-version-detection=true` or `--skip-version-detection=false`.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub skip_version_detection: Option<bool>,
 
     /// Ignore `@notice` for these items (can be used more than once)
     #[arg(long)]
@@ -576,6 +590,10 @@ pub fn read_config(args: Args) -> Result<Config> {
     }
     if let Some(sort) = args.sort {
         config.output.sort = sort;
+    }
+    // parser
+    if let Some(skip_version_detection) = args.skip_version_detection {
+        config.lintspec.skip_version_detection = skip_version_detection;
     }
     // natspec config
     if let Some(inheritdoc) = args.inheritdoc {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,20 @@ fn main() -> Result<()> {
 
     // lint all the requested Solidity files
     let options: ValidationOptions = (&config).into();
+    let parser = SlangParser::builder()
+        .skip_version_detection(config.lintspec.skip_version_detection)
+        .build();
     let diagnostics = paths
         .par_iter()
         .filter_map(|p| {
-            lint::<SlangParser>(p, &options, !config.output.compact && !config.output.json)
-                .map_err(Into::into)
-                .transpose()
+            lint(
+                parser.clone(),
+                p,
+                &options,
+                !config.output.compact && !config.output.json,
+            )
+            .map_err(Into::into)
+            .transpose()
         })
         .collect::<Result<Vec<_>>>()?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ use crate::{definitions::Definition, error::Result};
 pub mod slang;
 
 /// The result of parsing and identifying source items in a document
+#[derive(Debug)]
 pub struct ParsedDocument {
     /// The list of definitions found in the document
     pub definitions: Vec<Definition>,
@@ -17,5 +18,11 @@ pub struct ParsedDocument {
 /// The trait implemented by all parsers
 pub trait Parse {
     /// Parse a document at `path` and identify the relevant source items
-    fn parse_document(path: impl AsRef<Path>, keep_contents: bool) -> Result<ParsedDocument>;
+    ///
+    /// The fact that this takes in a mutable reference to the parser allows for stateful parsers.
+    fn parse_document(
+        &mut self,
+        path: impl AsRef<Path>,
+        keep_contents: bool,
+    ) -> Result<ParsedDocument>;
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -16,13 +16,18 @@ use crate::{
     },
     error::{Error, Result},
     natspec::{parse_comment, NatSpec},
-    utils::detect_solidity_version,
+    utils::{detect_solidity_version, get_latest_supported_version},
 };
 
 use super::{Parse, ParsedDocument};
 
 /// A parser that uses [`slang_solidity`] to identify source items
-pub struct SlangParser {}
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct SlangParser {
+    #[builder(default)]
+    pub skip_version_detection: bool,
+}
 
 impl SlangParser {
     /// The `slang` queries for all source items
@@ -94,6 +99,7 @@ impl SlangParser {
 
 impl Parse for SlangParser {
     fn parse_document(
+        &mut self,
         path: impl AsRef<std::path::Path>,
         keep_contents: bool,
     ) -> Result<ParsedDocument> {
@@ -102,7 +108,11 @@ impl Parse for SlangParser {
                 path: path.as_ref().to_path_buf(),
                 err,
             })?;
-            let solidity_version = detect_solidity_version(&contents)?;
+            let solidity_version = if self.skip_version_detection {
+                get_latest_supported_version()
+            } else {
+                detect_solidity_version(&contents)?
+            };
             let parser = Parser::create(solidity_version).expect("parser should initialize");
             let output = parser.parse(NonterminalKind::SourceUnit, &contents);
             (keep_contents.then_some(contents), output)
@@ -1271,5 +1281,12 @@ mod tests {
         let parser = Parser::create(solidity_version).unwrap();
         let output = parser.parse(NonterminalKind::SourceUnit, contents);
         assert!(output.is_valid(), "{:?}", output.errors());
+    }
+
+    #[test]
+    fn test_parse_solidity_unsupported() {
+        let mut parser = SlangParser::builder().skip_version_detection(true).build();
+        let output = parser.parse_document("test-data/UnsupportedVersion.sol", false);
+        assert!(output.is_ok(), "{output:?}");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,13 +58,8 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
         return Ok(Version::new(0, 8, 0));
     };
 
-    let parser = Parser::create(
-        Parser::SUPPORTED_VERSIONS
-            .last()
-            .expect("the SUPPORTED_VERSIONS list should not be empty")
-            .to_owned(),
-    )
-    .expect("the Parser should be initialized correctly with a supported solidity version");
+    let parser = Parser::create(get_latest_supported_version())
+        .expect("the Parser should be initialized correctly with a supported solidity version");
 
     let parse_result = parser.parse(NonterminalKind::PragmaDirective, pragma.as_str());
     if !parse_result.is_valid() {
@@ -136,4 +131,13 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
         .max()
         .cloned()
         .ok_or_else(|| Error::SolidityUnsupportedVersion(pragma.as_str().to_string()))
+}
+
+/// Get the latest Solidity version supported by the [`slang_solidity`] parser
+#[must_use]
+pub fn get_latest_supported_version() -> Version {
+    Parser::SUPPORTED_VERSIONS
+        .last()
+        .expect("the SUPPORTED_VERSIONS list should not be empty")
+        .to_owned()
 }

--- a/test-data/UnsupportedVersion.sol
+++ b/test-data/UnsupportedVersion.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.1234;
+
+contract UnsupportedVersion {}

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -15,7 +15,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
@@ -27,7 +28,8 @@ fn test_basic() {
 
 #[test]
 fn test_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::default(),
         true,
@@ -39,7 +41,8 @@ fn test_inheritdoc() {
 
 #[test]
 fn test_constructor() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -54,7 +57,8 @@ fn test_constructor() {
 
 #[test]
 fn test_struct() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -69,7 +73,8 @@ fn test_struct() {
 
 #[test]
 fn test_enum() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -84,7 +89,8 @@ fn test_enum() {
 
 #[test]
 fn test_all() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .constructors(WithParamsRules::required())
@@ -117,7 +123,8 @@ fn test_all() {
 
 #[test]
 fn test_all_no_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)

--- a/tests/tests-interface-sample.rs
+++ b/tests/tests-interface-sample.rs
@@ -5,7 +5,8 @@ use lintspec::{
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/InterfaceSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,

--- a/tests/tests-library-sample.rs
+++ b/tests/tests-library-sample.rs
@@ -14,7 +14,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/LibrarySample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,

--- a/tests/tests-parser-test.rs
+++ b/tests/tests-parser-test.rs
@@ -15,7 +15,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
@@ -27,7 +28,8 @@ fn test_basic() {
 
 #[test]
 fn test_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::default(),
         true,
@@ -39,7 +41,8 @@ fn test_inheritdoc() {
 
 #[test]
 fn test_constructor() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -54,7 +57,8 @@ fn test_constructor() {
 
 #[test]
 fn test_struct() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -69,7 +73,8 @@ fn test_struct() {
 
 #[test]
 fn test_enum() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)


### PR DESCRIPTION
* feat(config): add flag to skip solidity version detection

* feat!: allow for stateful parsers

The `Parse` trait's main method now takes in a mutable reference to the parser to allow for stateful and configurable parsers.

BREAKING CHANGE: the `lint::lint` method now takes in a parser instance. The `parser::Parse` trait's `parse_document` method now takes in `&mut self`.

* docs: fix link

* test(slang): add test for unsupported solidity version

* docs: update readme

* refactor(lint): improve monomorphisation