### PR TITLE
refactor(solar)!: some improvements and simplifications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,19 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  feature-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo hack
+        run: cargo hack check --feature-powerset --depth 2
+
   deny:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-hack
       - name: Run tests
-        run: cargo nextest run
+        run: cargo hack nextest run --feature-powerset --depth 2
 
   doctests:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,26 +50,6 @@ similar-asserts = "1.6.1"
 [features]
 solar = ["dep:solar-parse"]
 
-[[test]]
-name = "tests-basic-sample"
-path = "tests/tests-basic-sample.rs"
-required-features = ["solar"]
-
-[[test]]
-name = "tests-interface-sample"
-path = "tests/tests-interface-sample.rs"
-required-features = ["solar"]
-
-[[test]]
-name = "tests-library-sample"
-path = "tests/tests-library-sample.rs"
-required-features = ["solar"]
-
-[[test]]
-name = "tests-parser-test"
-path = "tests/tests-parser-test.rs"
-required-features = ["solar"]
-
 [profile.release]
 lto = "thin"
 

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains structs for each of the source item types that can be documented with `NatSpec`.
 //! The [`Definition`] type provides a unified interface to interact with the various types.
-use std::ops::Range;
+use std::{fmt, ops::Range};
 
 use constructor::ConstructorDefinition;
 use derive_more::{Display, From, IsVariant};
@@ -66,6 +66,12 @@ impl TextIndex {
         line: 0,
         column: 0,
     };
+}
+
+impl fmt::Display for TextIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.line + 1, self.column + 1)
+    }
 }
 
 impl PartialOrd for TextIndex {

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -12,7 +12,6 @@ use event::EventDefinition;
 use function::FunctionDefinition;
 use modifier::ModifierDefinition;
 use serde::{Deserialize, Serialize};
-use slang_solidity::cst::TextIndex as SlangTextIndex;
 use structure::StructDefinition;
 use variable::VariableDeclaration;
 
@@ -66,6 +65,29 @@ impl TextIndex {
         line: 0,
         column: 0,
     };
+
+    /// Advances the index, accounting for lf/nl/ls/ps characters and combinations.
+    /// This is *not* derived from the definition of 'newline' in the language definition,
+    /// nor is it a complete implementation of the Unicode line breaking algorithm.
+    ///
+    /// Implementation is directly taken from [`slang_solidity`].
+    #[inline]
+    pub fn advance(&mut self, c: char, next: Option<&char>) {
+        self.utf8 += c.len_utf8();
+        self.utf16 += c.len_utf16();
+        match (c, next) {
+            ('\r', Some('\n')) => {
+                // Ignore for now, we will increment the line number whe we process the \n
+            }
+            ('\n' | '\r' | '\u{2028}' | '\u{2029}', _) => {
+                self.line += 1;
+                self.column = 0;
+            }
+            _ => {
+                self.column += 1;
+            }
+        }
+    }
 }
 
 impl fmt::Display for TextIndex {
@@ -83,28 +105,6 @@ impl PartialOrd for TextIndex {
 impl Ord for TextIndex {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.utf8.cmp(&other.utf8)
-    }
-}
-
-impl From<SlangTextIndex> for TextIndex {
-    fn from(value: SlangTextIndex) -> Self {
-        Self {
-            utf8: value.utf8,
-            utf16: value.utf16,
-            line: value.line,
-            column: value.column,
-        }
-    }
-}
-
-impl From<TextIndex> for SlangTextIndex {
-    fn from(value: TextIndex) -> Self {
-        Self {
-            utf8: value.utf8,
-            utf16: value.utf16,
-            line: value.line,
-            column: value.column,
-        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     #[error("the provided Solidity version is not supported: `{0}`")]
     SolidityUnsupportedVersion(String),
 
-    #[error("there was an error while parsing the version pragma: {0}")]
+    #[error("there was an error while parsing solidity: {0}")]
     ParsingError(String),
 
     /// Error during parsing of a version specifier string

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! The error and result types for lintspec
 use std::path::PathBuf;
 
-use crate::definitions::{Parent, TextRange};
+use crate::definitions::{Parent, TextIndex, TextRange};
 
 /// The result of a lintspec operation
 pub type Result<T> = std::result::Result<T, Error>;
@@ -14,8 +14,12 @@ pub enum Error {
     #[error("the provided Solidity version is not supported: `{0}`")]
     SolidityUnsupportedVersion(String),
 
-    #[error("there was an error while parsing solidity: {0}")]
-    ParsingError(String),
+    #[error("there was an error while parsing {path}:{loc}:\n{message}")]
+    ParsingError {
+        path: PathBuf,
+        loc: TextIndex,
+        message: String,
+    },
 
     /// Error during parsing of a version specifier string
     #[error("error parsing a semver string: {0}")]

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -70,12 +70,7 @@ impl ItemDiagnostics {
             Ok(relative_path) => relative_path.to_string_lossy(),
             Err(_) => path.as_ref().to_string_lossy(),
         };
-        writeln!(
-            f,
-            "{source_name}:{}:{}",
-            self.span.start.line + 1,   // lines start at zero in the span
-            self.span.start.column + 1, // columsn start at zero in the span
-        )?;
+        writeln!(f, "{source_name}:{}", self.span.start)?;
         if let Some(parent) = &self.parent {
             writeln!(f, "{} {}.{}", self.item_type, parent, self.name)?;
         } else {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -144,7 +144,7 @@ pub fn lint(
         path: path.as_ref().to_path_buf(),
         err,
     })?;
-    let document = parser.parse_document(file, keep_contents)?;
+    let document = parser.parse_document(file, Some(&path), keep_contents)?;
     Ok(inner(path.as_ref(), document, options))
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
 //! Solidity parser interface
-use std::io;
+use std::{io, path::Path};
 
 use crate::{definitions::Definition, error::Result};
 
@@ -22,10 +22,12 @@ pub struct ParsedDocument {
 pub trait Parse {
     /// Parse a document from a reader and identify the relevant source items
     ///
+    /// If a path is provided, then this can be used to enrich diagnostics.
     /// The fact that this takes in a mutable reference to the parser allows for stateful parsers.
     fn parse_document(
         &mut self,
         input: impl io::Read,
+        path: Option<impl AsRef<Path>>,
         keep_contents: bool,
     ) -> Result<ParsedDocument>;
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -1,5 +1,8 @@
 //! A parser with `[slang_solidity]` backend
-use std::{io, path::PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 use slang_solidity::{
     cst::{Cursor, NonterminalKind, Query, QueryMatch, TerminalKind, TextRange as SlangTextRange},
@@ -101,6 +104,7 @@ impl Parse for SlangParser {
     fn parse_document(
         &mut self,
         mut input: impl io::Read,
+        _path: Option<impl AsRef<Path>>,
         keep_contents: bool,
     ) -> Result<ParsedDocument> {
         let (contents, output) = {
@@ -1321,7 +1325,7 @@ mod tests {
     fn test_parse_solidity_unsupported() {
         let mut parser = SlangParser::builder().skip_version_detection(true).build();
         let file = File::open("test-data/UnsupportedVersion.sol").unwrap();
-        let output = parser.parse_document(file, false);
+        let output = parser.parse_document(file, None::<PathBuf>, false);
         assert!(output.is_ok(), "{output:?}");
     }
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use slang_solidity::{
-    cst::{Cursor, NonterminalKind, Query, QueryMatch, TerminalKind, TextRange as SlangTextRange},
+    cst::{
+        Cursor, NonterminalKind, Query, QueryMatch, TerminalKind, TextIndex as SlangTextIndex,
+        TextRange as SlangTextRange,
+    },
     parser::Parser,
 };
 use winnow::Parser as _;
@@ -15,7 +18,7 @@ use crate::{
         constructor::ConstructorDefinition, enumeration::EnumDefinition, error::ErrorDefinition,
         event::EventDefinition, function::FunctionDefinition, modifier::ModifierDefinition,
         structure::StructDefinition, variable::VariableDeclaration, Attributes, Definition,
-        Identifier, Parent, TextRange, Visibility,
+        Identifier, Parent, TextIndex, TextRange, Visibility,
     },
     error::{Error, Result},
     natspec::{parse_comment, NatSpec},
@@ -741,6 +744,28 @@ pub fn find_definition_start(cursor: &Cursor) -> Option<TextRange> {
 #[must_use]
 pub fn textrange(value: SlangTextRange) -> TextRange {
     value.start.into()..value.end.into()
+}
+
+impl From<SlangTextIndex> for TextIndex {
+    fn from(value: SlangTextIndex) -> Self {
+        Self {
+            utf8: value.utf8,
+            utf16: value.utf16,
+            line: value.line,
+            column: value.column,
+        }
+    }
+}
+
+impl From<TextIndex> for SlangTextIndex {
+    fn from(value: TextIndex) -> Self {
+        Self {
+            utf8: value.utf8,
+            utf16: value.utf16,
+            line: value.line,
+            column: value.column,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -51,7 +51,8 @@ impl Parse for SolarParser {
             })?;
         let source_file = source_map
             .new_source_file(
-                path.map(|p| FileName::Real(p.as_ref().to_path_buf()))
+                path.as_ref()
+                    .map(|p| FileName::Real(p.as_ref().to_path_buf()))
                     .unwrap_or(FileName::Stdin),
                 buf,
             ) // should never fail since the content was read already
@@ -81,13 +82,16 @@ impl Parse for SolarParser {
                 let _ = visitor.visit_source_unit(&ast);
                 Ok(visitor.definitions)
             })
-            .map_err(|_| {
-                Error::ParsingError(
-                    sess.emitted_errors()
-                        .expect("should have a Result")
-                        .unwrap_err()
-                        .to_string(),
-                )
+            .map_err(|_| Error::ParsingError {
+                path: path
+                    .map(|p| p.as_ref().to_path_buf())
+                    .unwrap_or(PathBuf::from("stdin")),
+                loc: TextIndex::ZERO,
+                message: sess
+                    .emitted_errors()
+                    .expect("should have a Result")
+                    .unwrap_err()
+                    .to_string(),
             })?;
         drop(source_map);
         drop(sess);

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -445,14 +445,14 @@ impl From<&ItemContract<'_>> for Parent {
 
 /// Convert a [`Span`] to a [`TextRange`]
 fn span_to_text_range(span: Span, source_map: &SourceMap) -> TextRange {
-    let (source_file, range) = source_map
-        .span_to_source(span)
-        .expect("span must match the source");
+    let local_begin = source_map.lookup_byte_offset(span.lo());
+    let local_end = source_map.lookup_byte_offset(span.hi());
+    let range = local_begin.pos.to_usize()..local_end.pos.to_usize();
 
     let mut inside = false;
     let mut start = TextIndex::ZERO;
     let mut end = TextIndex::ZERO;
-    let mut iter = source_file.src.chars().peekable();
+    let mut iter = local_begin.sf.src.chars().peekable();
     while let Some(c) = iter.next() {
         if !inside {
             start.advance(c, iter.peek());

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -77,7 +77,10 @@ impl Parse for SolarParser {
         Ok(ParsedDocument {
             definitions,
             // retrieve the original source code if needed, without cloning
-            contents: keep_contents.then_some(Arc::into_inner(source_file.src.clone()).unwrap()),
+            contents: keep_contents.then_some(
+                Arc::into_inner(source_file.src.clone())
+                    .expect("all Arc references should have been dropped"),
+            ),
         })
     }
 }

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -461,6 +461,9 @@ fn span_to_text_range(span: Span, source_map: &SourceMap) -> TextRange {
                 end = start;
             }
         } else {
+            if end.utf8 >= range.end {
+                break;
+            }
             end.advance(c, iter.peek());
         }
     }

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -10,9 +10,7 @@ use solar_parse::{
     },
     Parser,
 };
-use std::io;
-use std::ops::ControlFlow;
-use std::path::PathBuf;
+use std::{io, ops::ControlFlow, path::PathBuf, sync::Arc};
 
 use crate::{
     definitions::{
@@ -36,88 +34,67 @@ impl Parse for SolarParser {
         mut input: impl io::Read,
         keep_contents: bool,
     ) -> Result<ParsedDocument> {
-        let sess = Session::builder().with_stderr_emitter().build();
-        let source_map = sess.source_map();
+        let source_map = SourceMap::empty();
+        let mut buf = String::new();
+        input
+            .read_to_string(&mut buf)
+            .map_err(|err| Error::IOError {
+                path: PathBuf::default(),
+                err,
+            })?;
+        let source_file = source_map
+            .new_source_file(FileName::Stdin, buf) // should never fail since the content was read already
+            .map_err(|err| Error::IOError {
+                path: PathBuf::default(),
+                err,
+            })?;
+        let source_map = Arc::new(source_map);
+        let sess = Session::builder()
+            .source_map(Arc::clone(&source_map))
+            .with_stderr_emitter()
+            .build();
 
-        // if keep_contents is true, we read it upfront (parsing is within a move closure, during the session below)
-        let mut content = String::new();
-        if keep_contents {
-            input
-                .read_to_string(&mut content)
-                .map_err(|_| Error::IOError {
-                    path: PathBuf::default(),
-                    err: io::Error::new(io::ErrorKind::Other, "Src file read error"),
-                })?;
-        }
-
-        let (definitions, contents) = sess.enter(|| -> Result<(Vec<Definition>, String)> {
+        let definitions = sess.enter(|| -> Result<_> {
             let arena = solar_parse::ast::Arena::new();
 
-            let content_for_parser = content.clone(); // either empty or the original content
+            let mut parser = Parser::from_source_file(&sess, &arena, &source_file);
 
-            let mut parser =
-                Parser::from_lazy_source_code(&sess, &arena, FileName::Stdin, move || {
-                    // if keep_contents is true, we reuse the content already read,
-                    // otherwise we read the content for the first time here
-                    if keep_contents {
-                        Ok(content_for_parser)
-                    } else {
-                        let mut buf = String::new();
-                        input.read_to_string(&mut buf)?;
-                        Ok(buf)
-                    }
-                })
-                .map_err(|_| Error::IOError {
-                    path: PathBuf::default(),
-                    err: io::Error::new(io::ErrorKind::Other, "Parsing error"),
-                })?;
-
-            let ast = parser.parse_file().map_err(|e| {
-                // this might be the error from the get_src closure above, when the closure is actually evaluated
-                e.clone().emit();
-                Error::IOError {
-                    path: PathBuf::new(),
-                    err: io::Error::new(io::ErrorKind::Other, format!("Parse failed: {e:?}")),
-                }
-            })?;
+            let ast = parser
+                .parse_file()
+                .map_err(|err| Error::ParsingError(err.label().to_string()))?;
 
             let mut visitor = LintspecVisitor {
                 current_parent: Vec::new(),
                 definitions: Vec::new(),
-                source_map,
+                source_map: &source_map,
             };
 
             let _ = visitor.visit_source_unit(&ast);
 
-            Ok((visitor.definitions, content))
+            Ok(visitor.definitions)
         })?;
 
-        if keep_contents {
-            Ok(ParsedDocument {
-                definitions,
-                contents: Some(contents),
-            })
-        } else {
-            Ok(ParsedDocument {
-                definitions,
-                contents: None,
-            })
-        }
+        Ok(ParsedDocument {
+            definitions,
+            // retrieve the original source code if needed, without cloning
+            contents: keep_contents.then_some(Arc::into_inner(source_file.src.clone()).unwrap()),
+        })
     }
 }
 
+/// A custom visitor to extract definitions from the [`solar_parse`] AST
+///
+/// Most of the items are visited using solar's default [`Visit`] implementation.
 pub struct LintspecVisitor<'ast> {
     current_parent: Vec<Parent>,
     definitions: Vec<Definition>,
     source_map: &'ast SourceMap,
 }
 
-/// A custom visitor to extract definitions from the AST (built with [`solar_parse`])
-/// most of the items are bisited using the Solar visitor
 impl<'ast> Visit<'ast> for LintspecVisitor<'ast> {
     type BreakValue = ();
 
-    /// Visit an item and extract definitions from it, using the corresponging trait
+    /// Visit an item and extract definitions from it, using the corresponding trait
     fn visit_item(&mut self, item: &'ast Item<'ast>) -> ControlFlow<Self::BreakValue> {
         match &item.kind {
             ItemKind::Pragma(item) => self.visit_pragma_directive(item)?,
@@ -125,38 +102,28 @@ impl<'ast> Visit<'ast> for LintspecVisitor<'ast> {
             ItemKind::Using(item) => self.visit_using_directive(item)?,
             ItemKind::Contract(item) => self.visit_item_contract(item)?,
             ItemKind::Function(item_function) => {
-                if let Some(def) =
-                    <solar_parse::ast::ItemFunction as Extract>::extract_definition(self, item)
-                {
+                if let Some(def) = item_function.extract_definition(item, self) {
                     self.definitions.push(def);
                 }
 
                 self.visit_item_function(item_function)?;
             }
             ItemKind::Variable(var_def) => {
-                if let Some(def) =
-                    <solar_parse::ast::VariableDefinition as Extract>::extract_definition(
-                        self, item,
-                    )
-                {
+                if let Some(def) = var_def.extract_definition(item, self) {
                     self.definitions.push(def);
                 }
 
                 self.visit_variable_definition(var_def)?;
             }
-            ItemKind::Struct(strukt) => {
-                if let Some(struct_def) =
-                    <solar_parse::ast::ItemStruct as Extract>::extract_definition(self, item)
-                {
-                    self.definitions.push(struct_def);
+            ItemKind::Struct(item_struct) => {
+                if let Some(def) = item_struct.extract_definition(item, self) {
+                    self.definitions.push(def);
                 }
 
-                self.visit_item_struct(strukt)?;
+                self.visit_item_struct(item_struct)?;
             }
             ItemKind::Enum(item_enum) => {
-                if let Some(enum_def) =
-                    <solar_parse::ast::ItemEnum as Extract>::extract_definition(self, item)
-                {
+                if let Some(enum_def) = item_enum.extract_definition(item, self) {
                     self.definitions.push(enum_def);
                 }
 
@@ -164,18 +131,14 @@ impl<'ast> Visit<'ast> for LintspecVisitor<'ast> {
             }
             ItemKind::Udvt(item) => self.visit_item_udvt(item)?,
             ItemKind::Error(item_error) => {
-                if let Some(def) =
-                    <solar_parse::ast::ItemError as Extract>::extract_definition(self, item)
-                {
+                if let Some(def) = item_error.extract_definition(item, self) {
                     self.definitions.push(def);
                 }
 
                 self.visit_item_error(item_error)?;
             }
             ItemKind::Event(item_event) => {
-                if let Some(def) =
-                    <solar_parse::ast::ItemEvent as Extract>::extract_definition(self, item)
-                {
+                if let Some(def) = item_event.extract_definition(item, self) {
                     self.definitions.push(def);
                 }
 
@@ -199,7 +162,7 @@ impl<'ast> Visit<'ast> for LintspecVisitor<'ast> {
             ..
         } = contract;
 
-        self.current_parent.push(item_contract_to_parent(contract));
+        self.current_parent.push(contract.into());
 
         self.visit_ident(name)?;
         for base in bases.iter() {
@@ -215,286 +178,246 @@ impl<'ast> Visit<'ast> for LintspecVisitor<'ast> {
     }
 }
 
-/// Extract each "component" (parent, params, span, etc) then build a definition from it
-trait Extract<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition>;
+/// Extract each "component" (parent, params, span, etc) then build a [`Definition`] from it
+trait Extract {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition>;
 }
 
-impl<'ast> Extract<'ast> for solar_parse::ast::ItemFunction<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
-        if let ItemKind::Function(item_function) = &item.kind {
-            let parent = visitor.current_parent.last().cloned();
-            let params = variable_definitions_to_identifiers(
-                item_function.header.parameters,
-                visitor.source_map,
-            );
-
-            let extracted_natspec =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
-            let returns = variable_definitions_to_identifiers(
-                item_function.header.returns,
-                visitor.source_map,
-            );
-
-            let span = if let Some((_, span)) = extracted_natspec {
-                span_to_text_range(span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
-
-            let natspec = extracted_natspec.map(|(ns, _)| ns.populate_returns(&returns));
-
-            let def = if item_function.kind.is_constructor() {
-                Definition::Constructor(ConstructorDefinition {
-                    parent,
-                    span,
-                    params,
-                    natspec,
-                })
-            } else if item_function.kind.is_modifier() {
-                Definition::Modifier(ModifierDefinition {
-                    parent,
-                    span,
-                    params,
-                    natspec,
-                    name: item_function.header.name.unwrap().to_string(),
-                    attributes: Attributes {
-                        visibility: item_function.header.visibility.into(),
-                        r#override: item_function.header.override_.is_some(),
-                    },
-                })
-            } else if item_function.kind.is_function() {
-                Definition::Function(FunctionDefinition {
-                    parent,
-                    name: item_function.header.name.unwrap().to_string(),
-                    returns: returns.clone(),
-                    attributes: Attributes {
-                        visibility: item_function.header.visibility.into(),
-                        r#override: item_function.header.override_.is_some(),
-                    },
-                    span,
-                    params,
-                    natspec,
-                })
-            } else {
-                return None;
-            };
-
-            Some(def)
-        } else {
-            None
-        }
-    }
-}
-
-impl<'ast> Extract<'ast> for solar_parse::ast::VariableDefinition<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
+impl Extract for &solar_parse::ast::ItemFunction<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
         let parent = visitor.current_parent.last().cloned();
+        let params =
+            variable_definitions_to_identifiers(self.header.parameters, visitor.source_map);
 
-        if let ItemKind::Variable(item_variable) = &item.kind {
-            let extracted_natspec =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+        let extracted_natspec =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+        let returns = variable_definitions_to_identifiers(self.header.returns, visitor.source_map);
 
-            let span = if let Some((_, span)) = extracted_natspec {
-                span_to_text_range(span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
+        let span = if let Some((_, span)) = extracted_natspec {
+            span_to_text_range(span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
 
-            let natspec = if let Some((natspec, _)) = extracted_natspec {
-                Some(natspec)
-            } else {
-                None
-            };
+        let natspec = extracted_natspec.map(|(ns, _)| ns.populate_returns(&returns));
 
-            let attributes = Attributes {
-                visibility: item_variable.visibility.into(),
-                r#override: item_variable.override_.is_some(),
-            };
-
-            Some(Definition::Variable(VariableDeclaration {
+        let def = if self.kind.is_constructor() {
+            Definition::Constructor(ConstructorDefinition {
                 parent,
-                name: item_variable.name.unwrap().to_string(),
-                span,
-                natspec,
-                attributes,
-            }))
-        } else {
-            None
-        }
-    }
-}
-
-impl<'ast> Extract<'ast> for solar_parse::ast::ItemStruct<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
-        let parent = visitor.current_parent.last().cloned();
-
-        if let ItemKind::Struct(strukt) = &item.kind {
-            let name = strukt.name.to_string();
-
-            let members = strukt
-                .fields
-                .iter()
-                .map(|m| Identifier {
-                    name: Some(m.name.expect("name").to_string()),
-                    span: span_to_text_range(m.span, visitor.source_map),
-                })
-                .collect();
-
-            let extracted_natspec =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
-
-            let span = if let Some((_, doc_span)) = &extracted_natspec {
-                span_to_text_range(*doc_span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
-
-            let natspec = extracted_natspec.map(|(ns, _)| ns);
-
-            Some(Definition::Struct(StructDefinition {
-                parent,
-                name,
-                span,
-                members,
-                natspec,
-            }))
-        } else {
-            None
-        }
-    }
-}
-
-impl<'ast> Extract<'ast> for solar_parse::ast::ItemEnum<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
-        let parent = visitor.current_parent.last().cloned();
-
-        if let ItemKind::Enum(item_enum) = &item.kind {
-            let members = item_enum
-                .variants
-                .iter()
-                .map(|v| Identifier {
-                    name: Some(v.name.to_string()),
-                    span: span_to_text_range(v.span, visitor.source_map),
-                })
-                .collect();
-
-            let extracted =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
-
-            let span = if let Some((_, doc_span)) = &extracted {
-                span_to_text_range(*doc_span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
-
-            let natspec = extracted.map(|(ns, _)| ns);
-
-            Some(Definition::Enumeration(EnumDefinition {
-                parent: parent.clone(),
-                name: item_enum.name.to_string(),
-                span,
-                members,
-                natspec,
-            }))
-        } else {
-            None
-        }
-    }
-}
-
-impl<'ast> Extract<'ast> for solar_parse::ast::ItemError<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
-        let parent = visitor.current_parent.last().cloned();
-
-        if let ItemKind::Error(item_error) = &item.kind {
-            let params =
-                variable_definitions_to_identifiers(item_error.parameters, visitor.source_map);
-
-            let extracted_natspec =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
-
-            let natspec = extracted_natspec.clone().map(|(ns, _)| ns);
-
-            let span = if let Some((_, span)) = extracted_natspec {
-                span_to_text_range(span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
-
-            Some(Definition::Error(ErrorDefinition {
-                parent: parent.clone(),
-                span,
-                name: item_error.name.to_string(),
-                params,
-                natspec,
-            }))
-        } else {
-            None
-        }
-    }
-}
-
-impl<'ast> Extract<'ast> for solar_parse::ast::ItemEvent<'ast> {
-    fn extract_definition(
-        visitor: &mut LintspecVisitor<'ast>,
-        item: &'ast Item<'ast>,
-    ) -> Option<Definition> {
-        let parent = visitor.current_parent.last().cloned();
-
-        if let ItemKind::Event(item_event) = &item.kind {
-            let params =
-                variable_definitions_to_identifiers(item_event.parameters, visitor.source_map);
-
-            let extracted_natspec =
-                extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
-
-            let span = if let Some((_, span)) = extracted_natspec {
-                span_to_text_range(span, visitor.source_map)
-            } else {
-                span_to_text_range(item.span, visitor.source_map)
-            };
-
-            let natspec = if let Some((natspec, _)) = extracted_natspec {
-                Some(natspec)
-            } else {
-                None
-            };
-
-            Some(Definition::Event(EventDefinition {
-                parent: parent.clone(),
-                name: item_event.name.to_string(),
                 span,
                 params,
                 natspec,
-            }))
+            })
+        } else if self.kind.is_modifier() {
+            Definition::Modifier(ModifierDefinition {
+                parent,
+                span,
+                params,
+                natspec,
+                name: self.header.name.unwrap().to_string(),
+                attributes: Attributes {
+                    visibility: self.header.visibility.into(),
+                    r#override: self.header.override_.is_some(),
+                },
+            })
+        } else if self.kind.is_function() {
+            Definition::Function(FunctionDefinition {
+                parent,
+                name: self.header.name.unwrap().to_string(),
+                returns: returns.clone(),
+                attributes: Attributes {
+                    visibility: self.header.visibility.into(),
+                    r#override: self.header.override_.is_some(),
+                },
+                span,
+                params,
+                natspec,
+            })
+        } else {
+            return None;
+        };
+
+        Some(def)
+    }
+}
+
+impl Extract for &solar_parse::ast::VariableDefinition<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        let parent = visitor.current_parent.last().cloned();
+
+        let extracted_natspec =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+
+        let span = if let Some((_, span)) = extracted_natspec {
+            span_to_text_range(span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
+
+        let natspec = if let Some((natspec, _)) = extracted_natspec {
+            Some(natspec)
         } else {
             None
+        };
+
+        let attributes = Attributes {
+            visibility: self.visibility.into(),
+            r#override: self.override_.is_some(),
+        };
+
+        Some(Definition::Variable(VariableDeclaration {
+            parent,
+            name: self.name.unwrap().to_string(),
+            span,
+            natspec,
+            attributes,
+        }))
+    }
+}
+
+impl Extract for &solar_parse::ast::ItemStruct<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        let parent = visitor.current_parent.last().cloned();
+
+        let name = self.name.to_string();
+
+        let members = self
+            .fields
+            .iter()
+            .map(|m| Identifier {
+                name: Some(m.name.expect("name").to_string()),
+                span: span_to_text_range(m.span, visitor.source_map),
+            })
+            .collect();
+
+        let extracted_natspec =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+
+        let span = if let Some((_, doc_span)) = &extracted_natspec {
+            span_to_text_range(*doc_span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
+
+        let natspec = extracted_natspec.map(|(ns, _)| ns);
+
+        Some(Definition::Struct(StructDefinition {
+            parent,
+            name,
+            span,
+            members,
+            natspec,
+        }))
+    }
+}
+
+impl Extract for &solar_parse::ast::ItemEnum<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        let parent = visitor.current_parent.last().cloned();
+
+        let members = self
+            .variants
+            .iter()
+            .map(|v| Identifier {
+                name: Some(v.name.to_string()),
+                span: span_to_text_range(v.span, visitor.source_map),
+            })
+            .collect();
+
+        let extracted =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+
+        let span = if let Some((_, doc_span)) = &extracted {
+            span_to_text_range(*doc_span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
+
+        let natspec = extracted.map(|(ns, _)| ns);
+
+        Some(Definition::Enumeration(EnumDefinition {
+            parent: parent.clone(),
+            name: self.name.to_string(),
+            span,
+            members,
+            natspec,
+        }))
+    }
+}
+
+impl Extract for &solar_parse::ast::ItemError<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        let parent = visitor.current_parent.last().cloned();
+
+        let params = variable_definitions_to_identifiers(self.parameters, visitor.source_map);
+
+        let extracted_natspec =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+
+        let natspec = extracted_natspec.clone().map(|(ns, _)| ns);
+
+        let span = if let Some((_, span)) = extracted_natspec {
+            span_to_text_range(span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
+
+        Some(Definition::Error(ErrorDefinition {
+            parent: parent.clone(),
+            span,
+            name: self.name.to_string(),
+            params,
+            natspec,
+        }))
+    }
+}
+
+impl Extract for &solar_parse::ast::ItemEvent<'_> {
+    fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        let parent = visitor.current_parent.last().cloned();
+
+        let params = variable_definitions_to_identifiers(self.parameters, visitor.source_map);
+
+        let extracted_natspec =
+            extract_natspec(&item.docs, visitor.source_map, parent.as_ref()).unwrap_or(None);
+
+        let span = if let Some((_, span)) = extracted_natspec {
+            span_to_text_range(span, visitor.source_map)
+        } else {
+            span_to_text_range(item.span, visitor.source_map)
+        };
+
+        let natspec = if let Some((natspec, _)) = extracted_natspec {
+            Some(natspec)
+        } else {
+            None
+        };
+
+        Some(Definition::Event(EventDefinition {
+            parent: parent.clone(),
+            name: self.name.to_string(),
+            span,
+            params,
+            natspec,
+        }))
+    }
+}
+
+/// Create a [`Parent`] from solar's [`ItemContract`]
+impl From<&ItemContract<'_>> for Parent {
+    fn from(contract: &ItemContract) -> Self {
+        match contract.kind {
+            ContractKind::Contract | ContractKind::AbstractContract => {
+                Parent::Contract(contract.name.to_string())
+            }
+            ContractKind::Library => Parent::Library(contract.name.to_string()),
+            ContractKind::Interface => Parent::Interface(contract.name.to_string()),
         }
     }
 }
 
-// @todo build the utf16 representation
-/// Convert a Solar ``Span`` to a lintspec ``TextRange``
-/// @dev For now, this does NOT handle the utf16 representation
+/// Convert a [`Span`] to a [`TextRange`]
+/// TODO: build the utf16 representation
 fn span_to_text_range(span: Span, source_map: &SourceMap) -> TextRange {
     let (_, lo_line, lo_col, hi_line, hi_col) = source_map.span_to_location_info(span);
 
@@ -511,7 +434,7 @@ fn span_to_text_range(span: Span, source_map: &SourceMap) -> TextRange {
     start..end
 }
 
-/// Convert a list of Solar ``VariableDefinition`` (used for fn params or returns) to the corresponding Lintspec ``Identifier``
+/// Convert a list of [`VariableDefinition`] (used for fn params or returns) into an [`Identifier`]
 fn variable_definitions_to_identifiers(
     variable_definitions: &[VariableDefinition<'_>],
     source_map: &SourceMap,
@@ -529,18 +452,7 @@ fn variable_definitions_to_identifiers(
         .collect()
 }
 
-/// Convert a Solar ``ItemContract`` to the local Parent type
-fn item_contract_to_parent(contract: &ItemContract) -> Parent {
-    match contract.kind {
-        ContractKind::Contract | ContractKind::AbstractContract => {
-            Parent::Contract(contract.name.to_string())
-        }
-        ContractKind::Library => Parent::Library(contract.name.to_string()),
-        ContractKind::Interface => Parent::Interface(contract.name.to_string()),
-    }
-}
-
-/// Convert the Solar ``DocComments`` to the Lintspec ``NatSpec`` and ``Span`` type
+/// Convert solar's [`DocComments`] into a [`NatSpec`] and [`Span`]
 fn extract_natspec(
     docs: &DocComments,
     source_map: &SourceMap,
@@ -573,7 +485,7 @@ fn extract_natspec(
     Ok(Some((combined, docs.span())))
 }
 
-/// Convert a Solar visibility type to the corresponding lintspec Visibility type
+/// Convert solar's [`ast::Visibility`][solar_parse::ast::Visibility] into to the corresponding [`Visibility`] type
 impl From<Option<solar_parse::ast::Visibility>> for Visibility {
     fn from(visibility: Option<solar_parse::ast::Visibility>) -> Self {
         match visibility {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,21 +37,22 @@ static REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// # Examples
 ///
 /// ```
+/// # use std::path::PathBuf;
 /// # use lintspec::utils::{detect_solidity_version, semver::Version};
 /// assert_eq!(
-///     detect_solidity_version("pragma solidity >=0.8.4 <0.8.26;").unwrap(),
+///     detect_solidity_version("pragma solidity >=0.8.4 <0.8.26;", PathBuf::from("./file.sol")).unwrap(),
 ///     Version::new(0, 8, 25)
 /// );
 /// assert_eq!(
-///     detect_solidity_version("pragma solidity ^0.4.0 || 0.6.x;").unwrap(),
+///     detect_solidity_version("pragma solidity ^0.4.0 || 0.6.x;", PathBuf::from("./file.sol")).unwrap(),
 ///     Version::new(0, 6, 12)
 /// );
 /// assert_eq!(
-///     detect_solidity_version("contract Foo {}").unwrap(),
+///     detect_solidity_version("contract Foo {}", PathBuf::from("./file.sol")).unwrap(),
 ///     Version::new(0, 8, 0)
 /// );
 /// // this version of Solidity does not exist
-/// assert!(detect_solidity_version("pragma solidity 0.7.7;").is_err());
+/// assert!(detect_solidity_version("pragma solidity 0.7.7;", PathBuf::from("./file.sol")).is_err());
 /// ```
 pub fn detect_solidity_version(src: &str, path: impl AsRef<Path>) -> Result<Version> {
     let Some(pragma) = REGEX.find(src) else {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,30 +1,34 @@
-use lintspec::{lint::FileDiagnostics, print_reports};
+use lintspec::{
+    lint::{lint, FileDiagnostics, ValidationOptions},
+    parser::slang::SlangParser,
+    print_reports,
+};
 use std::path::PathBuf;
 
 #[cfg(feature = "solar")]
-use lintspec::{
-    lint::{lint, ValidationOptions},
-    parser::{slang::SlangParser, solar::SolarParser},
-};
+use lintspec::parser::solar::SolarParser;
+#[cfg(feature = "solar")]
+use similar_asserts::assert_eq;
 
 #[must_use]
-#[allow(dead_code)]
-pub fn generate_output(diags: FileDiagnostics) -> String {
+pub fn snapshot_content(path: &str, options: &ValidationOptions, keep_contents: bool) -> String {
+    let diags_slang = lint(SlangParser::builder().build(), path, options, keep_contents).unwrap();
+    let output = generate_output(diags_slang);
+
+    #[cfg(feature = "solar")]
+    {
+        let diags_solar = lint(SolarParser {}, path, options, keep_contents).unwrap();
+        assert_eq!(output, generate_output(diags_solar));
+    }
+
+    output
+}
+
+fn generate_output(diags: Option<FileDiagnostics>) -> String {
+    let Some(diags) = diags else {
+        return String::new();
+    };
     let mut buf = Vec::new();
     print_reports(&mut buf, PathBuf::new(), diags, true).unwrap();
     String::from_utf8(buf).unwrap()
-}
-
-#[cfg(feature = "solar")]
-#[must_use]
-pub fn multi_lint_handler(
-    path: &str,
-    options: &ValidationOptions,
-    keep_contents: bool,
-) -> (Option<FileDiagnostics>, Option<FileDiagnostics>) {
-    let diags_slang = lint(SlangParser::builder().build(), path, options, keep_contents).unwrap();
-
-    let diags_solar = lint(SolarParser {}, path, options, keep_contents).unwrap();
-
-    (diags_slang, diags_solar)
 }

--- a/tests/snapshots/tests_interface_sample__interface.snap
+++ b/tests/snapshots/tests_interface_sample__interface.snap
@@ -1,0 +1,5 @@
+---
+source: tests/tests-interface-sample.rs
+expression: "snapshot_content(\"./test-data/InterfaceSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).build(), true,)"
+---
+

--- a/tests/snapshots/tests_library_sample__basic.snap
+++ b/tests/snapshots/tests_library_sample__basic.snap
@@ -1,9 +1,0 @@
----
-source: tests/tests-library-sample.rs
-expression: generate_output(diags)
----
-./test-data/LibrarySample.sol:5:5
-function StringUtils.nothing
-  @notice is missing
-  @param input is missing
-  @return missing for unnamed return #1

--- a/tests/snapshots/tests_library_sample__library.snap
+++ b/tests/snapshots/tests_library_sample__library.snap
@@ -1,0 +1,9 @@
+---
+source: tests/tests-library-sample.rs
+expression: "snapshot_content(\"./test-data/LibrarySample.sol\",\n&ValidationOptions::builder().inheritdoc(false).build(), true,)"
+---
+./test-data/LibrarySample.sol:5:5
+function StringUtils.nothing
+  @notice is missing
+  @param input is missing
+  @return missing for unnamed return #1

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -2,114 +2,67 @@ use lintspec::{
     config::{NoticeDevRules, Req, VariableConfig, WithParamsRules},
     lint::ValidationOptions,
 };
-use similar_asserts::assert_eq;
 
 mod common;
 use common::*;
 
 #[test]
 fn test_basic() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-
-    insta::assert_snapshot!("basic", generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_inheritdoc() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::default(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_constructor() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .constructors(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_struct() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .structs(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_enum() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .enums(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_all() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .constructors(WithParamsRules::required())
@@ -134,21 +87,12 @@ fn test_all() {
             )
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_all_no_inheritdoc() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -174,14 +118,5 @@ fn test_all_no_inheritdoc() {
             )
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }

--- a/tests/tests-interface-sample.rs
+++ b/tests/tests-interface-sample.rs
@@ -4,13 +4,10 @@ mod common;
 use common::*;
 
 #[test]
-fn test_basic() {
-    let (diags_slang, diags_solar) = multi_lint_handler(
+fn test_interface() {
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/InterfaceSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
-    );
-
-    assert!(diags_slang.is_none(), "{diags_slang:?}");
-    assert!(diags_solar.is_none(), "{diags_solar:?}");
+    ));
 }

--- a/tests/tests-library-sample.rs
+++ b/tests/tests-library-sample.rs
@@ -4,20 +4,10 @@ mod common;
 use common::*;
 
 #[test]
-fn test_basic() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+fn test_library() {
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/LibrarySample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }

--- a/tests/tests-parser-test.rs
+++ b/tests/tests-parser-test.rs
@@ -1,104 +1,58 @@
 use lintspec::{config::WithParamsRules, lint::ValidationOptions};
-use similar_asserts::assert_eq;
 
 mod common;
 use common::*;
 
 #[test]
 fn test_basic() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_inheritdoc() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/ParserTest.sol",
         &ValidationOptions::default(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_constructor() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .constructors(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_struct() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .structs(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }
 
 #[test]
 fn test_enum() {
-    let (opt_slang, opt_solar) = multi_lint_handler(
+    insta::assert_snapshot!(snapshot_content(
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
             .enums(WithParamsRules::required())
             .build(),
         true,
-    );
-
-    let diags_slang = opt_slang.unwrap();
-    let diags_solar = opt_solar.unwrap();
-
-    assert_eq!(
-        generate_output(diags_slang.clone()),
-        generate_output(diags_solar)
-    );
-    insta::assert_snapshot!(generate_output(diags_slang));
+    ));
 }


### PR DESCRIPTION
Managed to avoid a clone of the source code, now the same buffer is re-used if requested by the caller.

Simplified the Extract trait while making it more type-safe, and remove superfluous lifetime parameters.
Parsing error handling has been improved too. Added the utf16 offset implementation.